### PR TITLE
Fix the feature openvpn_clients_revoke

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -16,6 +16,12 @@
   args: { creates: "{{ openvpn_keydir }}/{{item}}.crt" }
   with_items: openvpn_clients
 
+- name: Revoke Clients keys
+  command: "{{openvpn_etcdir}}/revoke-client.sh {{item}}"
+  args: { removes: "{{ openvpn_keydir }}/{{item}}.crt" }
+  with_items: openvpn_clients_revoke
+
+
 - name: Generate Clients configurations
   template: src=client.conf.j2 dest={{openvpn_keydir}}/{{item}}.ovpn
   with_items: openvpn_clients

--- a/templates/revoke-client.sh.j2
+++ b/templates/revoke-client.sh.j2
@@ -11,4 +11,4 @@ $EASY_RSA/revoke-full $@
 
 export CLIENT=$1
 
-rm -rf $KEY_DIR/$CLIENT
+rm -rf $KEY_DIR/$CLIENT*

--- a/templates/server.conf.j2
+++ b/templates/server.conf.j2
@@ -130,3 +130,7 @@ plugin {{ openvpn_use_ldap_plugin | default(openvpn_use_ldap_plugin_distribution
 {% for option in openvpn_server_options %}
 {{option}}
 {% endfor %}
+
+{% if openvpn_clients_revoke|length > 0 %}
+crl-verify {{openvpn_keydir}}/crl.pem
+{% endif %}


### PR DESCRIPTION
This PR basically correct functionality to revoke certificates, which in the state that are the settings currently does not.