### PR TITLE
Feature/check crl

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -23,6 +23,9 @@
   args: { removes: "{{ openvpn_keydir }}/{{item}}.crt" }
   with_items: openvpn_clients_revoke
 
+- name: Check if crl.pem exists
+  stat: path={{openvpn_keydir}}/crl.pem
+  register: crl_pem_file
 
 - name: Generate Clients configurations
   template: src=client.conf.j2 dest={{openvpn_keydir}}/{{item}}.ovpn

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -1,4 +1,6 @@
 ---
+- name: Ensure openvpn key dir has the right permission
+  file: path={{openvpn_keydir}} state=directory mode=0700 owner={{openvpn_user}}
 
 - name: Extract easy-rsa files
   unarchive: src=easy-rsa.tar.gz dest={{openvpn_etcdir}}

--- a/templates/server.conf.j2
+++ b/templates/server.conf.j2
@@ -131,6 +131,6 @@ plugin {{ openvpn_use_ldap_plugin | default(openvpn_use_ldap_plugin_distribution
 {{option}}
 {% endfor %}
 
-{% if openvpn_clients_revoke|length > 0 %}
+{% if openvpn_clients_revoke|length > 0  or crl_pem_file.stat.exists %}
 crl-verify {{openvpn_keydir}}/crl.pem
 {% endif %}


### PR DESCRIPTION
Hi again,

This pull request address if crl.pem file exists, but openvpn_clients_revoke is empty. If you maintain the user list in an automated way at some point the revoke list will be empty.

Thank you