### PR TITLE
Change order of tasks. to fix key dir creation

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -1,6 +1,4 @@
 ---
-- name: Ensure openvpn key dir has the right permission
-  file: path={{openvpn_keydir}} state=directory mode=0700 owner={{openvpn_user}}
 
 - name: Extract easy-rsa files
   unarchive: src=easy-rsa.tar.gz dest={{openvpn_etcdir}}
@@ -55,3 +53,6 @@
 - name: Configure server
   template: src=server.conf.j2 dest={{openvpn_etcdir}}/server.conf
   notify: [openvpn restart]
+
+- name: Ensure openvpn key dir has the right permission
+  file: path={{openvpn_keydir}} state=directory mode=0700 owner={{openvpn_user}}


### PR DESCRIPTION
Hi,

With my last pull request the role broke, due to creates will check the key dir and since it's already created by file it will skip.

I moved the task to the end of file. This should fix it.

Regards,
Adham