### PR TITLE
adding support for vivid

### DIFF
--- a/vars/Ubuntu.vivid.yml
+++ b/vars/Ubuntu.vivid.yml
@@ -1,0 +1,4 @@
+---
+
+openvpn_use_pam_plugin_distribution: /usr/lib/openvpn/openvpn-plugin-auth-pam.so
+openvpn_use_ldap_plugin_distribution: /usr/lib/openvpn/openvpn-auth-ldap.so


### PR DESCRIPTION
Not much work here, but needed for support on vivid.  Perhaps you get rid of the dependence on "distribution version" alltogether and just go with debian / fedora.

Tested on my dev vivid box .. didn't see any distro specific tests.