### PR TITLE
Allow using upstream OpenVPN repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ openvpn_enabled: yes                                # The role is enabled
 openvpn_etcdir: /etc/openvpn
 openvpn_keydir: "{{openvpn_etcdir}}/keys"
 
+# Installation settings
+openvpn_use_external_repo: false                    # Enable upstream OpenVPN repository
+
 # Default settings (See OpenVPN documentation)
 openvpn_host: "{{inventory_hostname}}"              # The server address
 openvpn_port: 1194

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,6 +5,9 @@ openvpn_enabled: yes                                # The role is enabled
 openvpn_etcdir: /etc/openvpn
 openvpn_keydir: "{{openvpn_etcdir}}/keys"
 
+# Installation settings
+openvpn_use_external_repo: false                    # Enable upstream OpenVPN repository
+
 # Default settings (See OpenVPN documentation)
 openvpn_host: "{{inventory_hostname}}"              # The server address
 openvpn_port: 1194

--- a/tasks/install.deb.yml
+++ b/tasks/install.deb.yml
@@ -1,5 +1,17 @@
 ---
 
+- name: Add OpenVPN repo GPG key
+  apt_key:
+    id: E158C569
+    url: https://swupdate.openvpn.net/repos/repo-public.gpg
+  when: openvpn_use_external_repo
+
+- name: Add OpenVPN repo sources
+  apt_repository:
+    filename: openvpn
+    repo: deb http://swupdate.openvpn.net/apt {{ ansible_lsb.codename }} main
+  when: openvpn_use_external_repo
+
 - name: Install requirements (Debian)
   apt: name={{item}} force=yes
   with_items: [openvpn, udev, openssl]


### PR DESCRIPTION
It's an useful option to get newer OpenVPN versions on older distributions such as Ubuntu Trusty or Debian Wheezy.