### PR TITLE
Fix OS-specific vars files naming

### DIFF
--- a/tasks/openvpn.yml
+++ b/tasks/openvpn.yml
@@ -3,9 +3,12 @@
 - name: Include OS-specific variables.
   include_vars: "{{item}}"
   with_first_found:
-  - "{{ ansible_os_family }}-{{ ansible_lsb.codename }}.yml"
-  - "{{ ansible_os_family }}.yml"
-  - "Common-default.yml"
+    - files:
+      - "{{ ansible_distribution }}.{{ ansible_lsb.codename }}.yml"
+      - "{{ ansible_distribution }}.yml"
+      - "{{ ansible_os_family }}.yml"
+      - "Common-default.yml"
+      paths: vars
 
 - include: install.deb.yml
   when: ansible_os_family == 'Debian'


### PR DESCRIPTION
`ansible_os_family` is Debian even in Ubuntu. It's necessary to use
`ansible_distribution` instead.

The task was also including the files with a dash separator, while it is
actually a dot.