### PR TITLE
Allow using easy-rsa package from system

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ openvpn_enabled: yes                                # The role is enabled
 openvpn_etcdir: /etc/openvpn
 openvpn_keydir: "{{openvpn_etcdir}}/keys"
 
+# Installation settings
+openvpn_use_system_easyrsa: false                   # Install EasyRSA from system packages
+
 # Default settings (See OpenVPN documentation)
 openvpn_host: "{{inventory_hostname}}"              # The server address
 openvpn_port: 1194

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,6 +5,9 @@ openvpn_enabled: yes                                # The role is enabled
 openvpn_etcdir: /etc/openvpn
 openvpn_keydir: "{{openvpn_etcdir}}/keys"
 
+# Installation settings
+openvpn_use_system_easyrsa: false                   # Install EasyRSA from system packages
+
 # Default settings (See OpenVPN documentation)
 openvpn_host: "{{inventory_hostname}}"              # The server address
 openvpn_port: 1194

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -2,6 +2,18 @@
 
 - name: Extract easy-rsa files
   unarchive: src=easy-rsa.tar.gz dest={{openvpn_etcdir}}
+  when: not openvpn_use_system_easyrsa
+
+- name: Check if easy-rsa 2.x is available from the system
+  stat: path=/usr/share/easy-rsa/build-ca
+  register: openvpn_easyrsa_check
+  when: openvpn_use_system_easyrsa
+
+- fail:
+    msg: >
+      EasyRSA 2.x is not present in /usr/share/easy-rsa.
+      Ensure the easy-rsa package is installed or disable the `openvpn_use_system_easyrsa` option.
+  when: openvpn_use_system_easyrsa and not openvpn_easyrsa_check.stat.exists
 
 - name: Generate scripts
   template: src={{item}}.j2 dest={{openvpn_etcdir}}/{{item}} mode=0700

--- a/tasks/install.deb.yml
+++ b/tasks/install.deb.yml
@@ -9,6 +9,10 @@
   when: openvpn_use_pam_users|default(false)
   with_items: [libpam-pwdfile, python-passlib]
 
+- name: Install easy-rsa package
+  apt: name=easy-rsa
+  when: openvpn_use_system_easyrsa
+
 - name: Install LDAP dependencies (Debian)
   apt: name=openvpn-auth-ldap force=yes
   when: openvpn_use_ldap

--- a/templates/vars.j2
+++ b/templates/vars.j2
@@ -2,7 +2,11 @@
 # Do NOT modify this file by hand!
 
 # easy-rsa parameter settings
+{% if openvpn_use_system_easyrsa %}
+export EASY_RSA=/usr/share/easy-rsa
+{% else %}
 export EASY_RSA="{{ openvpn_etcdir }}/easy-rsa"
+{% endif %}
 
 # This variable should point to
 # the requested executables


### PR DESCRIPTION
Debian and Ubuntu provide `easy-rsa` packages, that might have distribution customization, and that can receive updates as needed. Make it possible to use them instead of the provided EasyRSA binaries.