### PR TITLE
Fix include path

### DIFF
--- a/tasks/openvpn.yml
+++ b/tasks/openvpn.yml
@@ -8,7 +8,7 @@
       - "{{ ansible_distribution }}.yml"
       - "{{ ansible_os_family }}.yml"
       - "Common-default.yml"
-      paths: vars
+      paths: "{{ role_path }}/vars"
 
 - include: install.deb.yml
   when: ansible_os_family == 'Debian'


### PR DESCRIPTION
Not sure if this is due to the version of ansible I use (1.9.6), but it can't find the var files when running `include_vars`. Changing `paths` to be a relative path fixes the issue for me.
