### PR TITLE
Make LDAP client certificates optional/configurable and add new options for Bridge interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,12 +91,15 @@ openvpn_simple_auth_password: password
 # the network configuration is changed;
 # if this happens just run the playbook again
 openvpn_bridge:
+    ports: "eth0 tap0"
     address: 10.0.0.1
     netmask: 255.255.255.0
     network: 10.0.0.0
     broadcast: 10.0.0.255
     dhcp_start: 10.0.0.2
     dhcp_end: 10.0.0.254
+    script:
+      - post-up ip route add <...>
 openvpn_server_options:
     - "dev-type tap"
     - "tls-server"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -59,6 +59,10 @@ openvpn_use_pam_users: []                         # If empty use system users
 # LDAP authentication and configuration (optional)
 openvpn_use_ldap: no
 openvpn_ldap_tlsenable: 'no'
+openvpn_ldap_tls_cacert: '/etc/ssl/ca-cert.pem'
+openvpn_ldap_tls_use_clientcert: 'no'
+openvpn_ldap_tls_clientcert: '/etc/ssl/client-cert.pem'
+openvpn_ldap_tls_clientkey: '/etc/ssl/client-key.pem'
 openvpn_ldap_follow_referrals: 'no'
 
 # Use simple authentication (default is disabled)

--- a/templates/auth-ldap.conf.j2
+++ b/templates/auth-ldap.conf.j2
@@ -19,15 +19,16 @@
   FollowReferrals {{ openvpn_ldap_follow_referrals }}
 
   # TLS CA Certificate File
-  TLSCACertFile /etc/ssl/ca-cert.pem
+  TLSCACertFile {{ openvpn_ldap_tls_cacert }}
 
   # TLS CA Certificate Directory
   TLSCACertDir  /etc/ssl/certs
 
+  {% if openvpn_ldap_tls_use_clientcert != 'no' -%}
   # Client Certificate and key
   # If TLS client authentication is required
-  TLSCertFile /etc/ssl/client-cert.pem
-  TLSKeyFile  /etc/ssl/client-key.pem
+  TLSCertFile {{ openvpn_ldap_tls_clientcert }}
+  TLSKeyFile  {{ openvpn_ldap_tls_clientkey }}{% endif -%}
 
   # Cipher Suite
   # The defaults are usually fine here

--- a/templates/bridge-interface.j2
+++ b/templates/bridge-interface.j2
@@ -11,7 +11,9 @@ iface {{ openvpn_dev }} inet manual
 # Bridge
 auto br-{{ openvpn_dev }}
 iface br-{{ openvpn_dev }} inet static
-       bridge_ports {{ openvpn_bridge.ports }}
+       bridge_ports {% if 'ports' in openvpn_bridge %}{{ openvpn_bridge.ports }}
+       {% else %}{{ openvpn_dev }}
+       {% endif -%}
        bridge_stp off
        address {{openvpn_bridge.address}}
        netmask {{openvpn_bridge.netmask}}

--- a/templates/bridge-interface.j2
+++ b/templates/bridge-interface.j2
@@ -11,9 +11,12 @@ iface {{ openvpn_dev }} inet manual
 # Bridge
 auto br-{{ openvpn_dev }}
 iface br-{{ openvpn_dev }} inet static
-       bridge_ports {{ openvpn_dev }}
+       bridge_ports {{ openvpn_bridge.ports }}
        bridge_stp off
        address {{openvpn_bridge.address}}
        netmask {{openvpn_bridge.netmask}}
        network {{openvpn_bridge.network}}
        broadcast {{openvpn_bridge.broadcast}}
+       {% for line in openvpn_bridge.script -%}
+       {{ line }}
+       {% endfor %}


### PR DESCRIPTION
We don't use a client cert for connecting to LDAP, and the CA certificate path didn't match on Ubuntu 16.04, so this makes it optional and configurable.