### PR TITLE
Fix for jessie problem

### DIFF
--- a/vars/Debian.jessie.yml
+++ b/vars/Debian.jessie.yml
@@ -1,6 +1,6 @@
 ---
 
+openvpn_service: openvpn
 openvpn_use_pam_plugin_distribution: /usr/lib/openvpn/openvpn-plugin-auth-pam.so
 openvpn_use_ldap_plugin_distribution: /usr/lib/openvpn/openvpn-auth-ldap.so
 
-openvpn_service: openvpn@server


### PR DESCRIPTION
Fix for the jessie problem.

Note that this should also work with systemd. Just enable the service in /etc/defaults/openvpn as it is needed in all other setup too.