### PR TITLE
Update apt-cache before installing required packages

### DIFF
--- a/tasks/install.deb.yml
+++ b/tasks/install.deb.yml
@@ -12,6 +12,9 @@
     repo: deb http://swupdate.openvpn.net/apt {{ ansible_lsb.codename }} main
   when: openvpn_use_external_repo
 
+- name: Perform Apt Update
+  apt: update_cache=true
+
 - name: Install requirements (Debian)
   apt: name={{item}} force=yes
   with_items: [openvpn, udev, openssl, zip]


### PR DESCRIPTION
Installing packages with apt fails if apt mirrors are outdated/down/unavailable.

Performing an `apt-get update` before installing packages fixes the issue.