### PR TITLE
Fix for openvpn setup on 16.10

### DIFF
--- a/vars/Ubuntu.yakkety.yml
+++ b/vars/Ubuntu.yakkety.yml
@@ -1,0 +1,5 @@
+---
+openvpn_use_pam_plugin_distribution: /usr/lib/openvpn/openvpn-plugin-auth-pam.so
+openvpn_use_ldap_plugin_distribution: /usr/lib/openvpn/openvpn-auth-ldap.so
+
+openvpn_service: openvpn

--- a/vars/Ubuntu.zesty.yml
+++ b/vars/Ubuntu.zesty.yml
@@ -1,0 +1,5 @@
+---
+openvpn_use_pam_plugin_distribution: /usr/lib/openvpn/openvpn-plugin-auth-pam.so
+openvpn_use_ldap_plugin_distribution: /usr/lib/openvpn/openvpn-auth-ldap.so
+
+openvpn_service: openvpn


### PR DESCRIPTION
Related to https://github.com/Stouts/Stouts.openvpn/issues/45

Distributor ID: Ubuntu
Description:    Ubuntu 16.10
Release:        16.10
Codename:       yakkety

This fixes the issue for 16.10