### PR TITLE
Creates openvpn user and group

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -63,6 +63,19 @@
   notify: openvpn pack clients
   register: openvpn_clients_changed
 
+- name: Create system user
+  user:
+    name: "{{ openvpn_user }}"
+    shell: /usr/bin/nologin
+    system: 'yes'
+    state: present
+
+- name: Create system group
+  group:
+    name: "{{ openvpn_group }}"
+    system: 'yes'
+    state: present
+
 - name: Setup PAM
   template: src=openvpn.pam.j2 dest=/etc/pam.d/openvpn
   when: openvpn_use_pam


### PR DESCRIPTION
This basically creates the system user and group that openvpn is to run as. 

User creation is needed since, as it is now, if I configure the openvpn service to run eg as user "tterranigma" then it will fail if that user does not already exist in the system. 

Group creation is needed for the same reason and also for some edge cases. When running the role against an Ubuntu 16.04 installation, with the user 'nobody' and group 'nogroup', I found out that the group 'nogroup' did not exist which resulted in the tun0 interface not being created.

The extra overhead is minimal and the tasks complete really fast. I think the functionality should be included in the role to make it more robust and atomic, without requiring the user to guess about user/group creation and have them "patch" their playbooks to cater for it.