### PR TITLE
Replace include with import_tasks to avoid ansible deprecation warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+.vagrant
+*~
+*.retry
+.directory
+client_credentials

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,12 @@
 ---
+dist: trusty
 language: python
 python: "2.7"
 before_install:
  - sudo apt-get update -qq
  - sudo apt-get install -qq python-apt python-pycurl
 install:
+  - pip install netaddr
   - pip install ansible>=1.6.0
 script:
   # Prepare tests

--- a/README.md
+++ b/README.md
@@ -105,6 +105,9 @@ openvpn_server_options:
 # Whether to embed CA, cert, and key info inside client OVPN config file.
 openvpn_unified_client_profiles: no
 
+# Download the created client credentials to the specified directory
+openvpn_download_clients: no
+openvpn_download_dir: "client_credentials"
 ```
 
 #### Usage

--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ Ansible role which manage openvpn server
 
 #### Requirements
 
-Only tested on ubuntu for now.
+* Install python-netaddr
+* Only tested on ubuntu for now.
 
 #### Variables
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,43 +1,44 @@
 ---
 
-openvpn_enabled: yes                                # The role is enabled
+openvpn_enabled: yes                                        # The role is enabled
 
 openvpn_etcdir: /etc/openvpn
 openvpn_keydir: "{{openvpn_etcdir}}/keys"
 
 # Installation settings
-openvpn_use_external_repo: false                    # Enable upstream OpenVPN repository
-openvpn_use_system_easyrsa: false                   # Install EasyRSA from system packages
+openvpn_use_external_repo: false                            # Enable upstream OpenVPN repository
+openvpn_use_system_easyrsa: false                           # Install EasyRSA from system packages
 
 # Default settings (See OpenVPN documentation)
-openvpn_host: "{{inventory_hostname}}"              # The server address
+openvpn_host: "{{inventory_hostname}}"                      # The server address
+openvpn_interface: "{{ ansible_default_ipv4.interface }}"   # The interface that traffic will come in from
 openvpn_port: 1194
 openvpn_proto: udp
 openvpn_dev: tun
-openvpn_server: 10.8.0.0 255.255.255.0              # Set empty for skip
+openvpn_server: 10.8.0.0 255.255.255.0                      # Set empty for skip
 openvpn_bridge: {}
 openvpn_max_clients: 100
-openvpn_log: /var/log/openvpn.log                   # Log's directory
+openvpn_log: /var/log/openvpn.log                           # Log's directory
 openvpn_keepalive: "10 120"
 openvpn_ifconfig_pool_persist: ipp.txt
-openvpn_comp_lzo: yes                               # Enable compression
-openvpn_cipher: BF-CBC                              # Encryption algorithm
+openvpn_comp_lzo: yes                                       # Enable compression
+openvpn_cipher: BF-CBC                                      # Encryption algorithm
 openvpn_status: openvpn-status.log
 openvpn_verb: 3
-openvpn_tls_auth : False                            # Enable perfect forward secracyxy
-openvpn_tls_key  : "ta.key"
+openvpn_tls_auth: False                                     # Enable perfect forward secracyxy
+openvpn_tls_key: "ta.key"
 openvpn_user: nobody
 openvpn_group: nogroup
 openvpn_resolv_retry: infinite
 openvpn_client_to_client: yes
-openvpn_server_options: []                          # Additional server options
-                                                    # openvpn_server_options:
-                                                    # - dev-node MyTap
-                                                    # - client-to-client
-openvpn_client_options: []                          # Additional client options
-                                                    # openvpn_client_options:
-                                                    # - dev-node MyTap
-                                                    # - client-to-client
+openvpn_server_options: []                                  # Additional server options
+                                                            # openvpn_server_options:
+                                                            # - dev-node MyTap
+                                                            # - client-to-client
+openvpn_client_options: []                                  # Additional client options
+                                                            # openvpn_client_options:
+                                                            # - dev-node MyTap
+                                                            # - client-to-client
 
 openvpn_key_country: US
 openvpn_key_province: CA
@@ -46,15 +47,15 @@ openvpn_key_org: Fort-Funston
 openvpn_key_email: me@myhost.mydomain
 openvpn_key_size: 1024
 
-openvpn_clients: [client]                         # Make clients certificate
-openvpn_clients_revoke: []                        # Revoke clients certificates
+openvpn_clients: [client]                                   # Make clients certificate
+openvpn_clients_revoke: []                                  # Revoke clients certificates
 
 # Use PAM authentication
 openvpn_use_pam: yes
-openvpn_use_pam_users: []                         # If empty use system users
-                                                  # otherwise use users from the option
-                                                  # openvpn_use_pam_users:
-                                                  # - { name: user, password: password }
+openvpn_use_pam_users: []                                   # If empty use system users
+                                                            # otherwise use users from the option
+                                                            # openvpn_use_pam_users:
+                                                            # - { name: user, password: password }
 
 # LDAP authentication and configuration (optional)
 openvpn_use_ldap: no

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -68,3 +68,7 @@ openvpn_simple_auth_password: ""
 
 # Whether to embed CA, cert, and key info inside client OVPN config file.
 openvpn_unified_client_profiles: no
+
+# Download the created client credentials to the specified directory
+openvpn_download_clients: no
+openvpn_download_dir: "client_credentials/"

--- a/defaults/main.yml~
+++ b/defaults/main.yml~
@@ -31,6 +31,7 @@ openvpn_user: nobody
 openvpn_group: nogroup
 openvpn_resolv_retry: infinite
 openvpn_client_to_client: yes
+<<<<<<< HEAD
 openvpn_server_options: []                                  # Additional server options
                                                             # openvpn_server_options:
                                                             # - dev-node MyTap
@@ -39,10 +40,20 @@ openvpn_client_options: []                                  # Additional client 
                                                             # openvpn_client_options:
                                                             # - dev-node MyTap
                                                             # - client-to-client
+=======
+openvpn_server_options: []                          # Additional server options
+                                                    # openvpn_server_options:
+                                                    # - dev-node MyTap
+                                                    # - client-to-client
+openvpn_client_options: []                          # Additional client options
+                                                    # openvpn_client_options:
+                                                    # - dev-node MyTap
+                                                    # - client-to-client
 openvpn_dns: [                                              # DNS servers to use
   208.67.222.222,
   208.67.220.220
 ]
+>>>>>>> origin/dns
 
 openvpn_key_country: US
 openvpn_key_province: CA

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -9,3 +9,32 @@
   with_items: "{{openvpn_clients_changed.results}}"
   args:
     chdir: "{{ openvpn_keydir }}"
+  register: done_packing
+  listen: openvpn pack clients
+
+#- name: Download client credentials (zip)
+  #fetch:
+    #src: "{{ openvpn_keydir }}/{{ item.item }}.zip"
+    #dst: "{{ openvpn_download_dir }}"
+  #when: item.changed and openvpn_download_clients and not openvpn_unified_client_profiles
+  #with_items: "{{ openvpn_clients_changed.results }}"
+
+- name: Download client credentials (zip)
+  fetch:
+    src: "{{ openvpn_keydir }}/{{ item.item }}.zip"
+    dest: "{{ openvpn_download_dir }}"
+    flat: yes
+    validate_checksum: yes
+  when: item.changed and done_packing and openvpn_download_clients and not openvpn_unified_client_profiles
+  with_items: "{{ openvpn_clients_changed.results }}"
+  listen: openvpn pack clients
+
+- name: Download client credentials (ovpn)
+  fetch:
+    src: "{{ openvpn_keydir }}/{{ item.item }}.ovpn"
+    dest: "{{ openvpn_download_dir }}"
+    flat: yes
+    validate_checksum: yes
+  when: item.changed and done_packing and openvpn_download_clients and openvpn_unified_client_profiles
+  with_items: "{{ openvpn_clients_changed.results }}"
+  listen: openvpn pack clients

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -63,6 +63,19 @@
   notify: openvpn pack clients
   register: openvpn_clients_changed
 
+- name: Create system user
+  user:
+    name: "{{ openvpn_user }}"
+    shell: /usr/bin/nologin
+    system: 'yes'
+    state: present
+
+- name: Create system group
+  group:
+    name: "{{ openvpn_group }}"
+    system: 'yes'
+    state: present
+
 - name: Setup PAM
   template: src=openvpn.pam.j2 dest=/etc/pam.d/openvpn
   when: openvpn_use_pam

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -43,7 +43,7 @@
   args: { removes: "{{ openvpn_keydir }}/{{item}}.crt" }
   with_items: "{{ openvpn_clients_revoke }}"
 
-- include: read-client-files.yml
+- import_tasks: read-client-files.yml
   when: openvpn_unified_client_profiles
 
 - name: Create client configuration directory if requested

--- a/tasks/firewall.yml
+++ b/tasks/firewall.yml
@@ -1,0 +1,86 @@
+---
+
+# based on http://www.hashbangcode.com/blog/adding-iptables-rules-ansible
+- name: Read existing iptable rules
+  shell: iptables -L
+  register: iptables_rules
+  check_mode: no
+  changed_when: false
+
+- name: Read existing iptable rules (nat table)
+  shell: iptables -L -t nat
+  register: iptables_nat_rules
+  check_mode: no
+  changed_when: false
+
+- name: Allow connections to the OpenVPN server
+  iptables:
+    chain: INPUT
+    in_interface: "{{ openvpn_interface }}"
+    ctstate: NEW
+    protocol: udp
+    destination_port: "{{ openvpn_port }}"
+    jump: ACCEPT
+    comment: incoming_openvpn
+  register: rules
+  when: iptables_rules.stdout.find("incoming_openvpn") == -1
+
+- name: Allow forwarding from tun/tap to interface
+  iptables:
+    chain: FORWARD
+    in_interface: "{{ openvpn_dev }}+"
+    out_interface: "{{ openvpn_interface }}"
+    jump: ACCEPT
+    comment: forward_tun_tap
+  register: rules
+  when: iptables_rules.stdout.find("forward_tun_tap") == -1
+
+- name: Allow forwarding from interface to tun/tap
+  iptables:
+    chain: FORWARD
+    in_interface: "{{ openvpn_interface }}"
+    out_interface: "{{ openvpn_dev }}+"
+    jump: ACCEPT
+    comment: forward_reverse
+  register: rules
+  when: iptables_rules.stdout.find("forward_reverse") == -1
+
+- name: Allow NATing outgoing vpn traffic
+  iptables:
+    table: nat
+    chain: POSTROUTING
+    source: "{{ openvpn_server | regex_replace('^(?P<host>.+)\\s(?P<mask>.+)$', '\\g<host>/\\g<mask>') | ipaddr('net') }}"
+    out_interface: "{{ openvpn_interface }}"
+    jump: MASQUERADE
+    comment: vpn_masquerade
+  register: rules
+  when: iptables_nat_rules.stdout.find("vpn_masquerade") == -1 and openvpn_server != ""
+
+- name: Save the rules (RedHat)
+  command: iptables-save
+  when: rules.changed and ansible_os_family == "RedHat"
+
+- name: Install iptables-peristent (Debian)
+  apt:
+    name: iptables-persistent
+    force: yes
+
+- name: Save the rules (Debian)
+  command: /etc/init.d/iptables-persistent save
+  when: rules.changed and ansible_os_family == "Debian" and ansible_lsb.codename == "trusty"
+
+- name: Save the rules
+  command: netfilter-persistent save
+  when: rules.changed and ansible_os_family == "Debian" and ansible_lsb.codename != "trusty"
+
+# - name: Reload the firewall service
+#   service:
+#     name: firewalld
+#     state: reloaded
+#   when: ansible_os_family == "RedHat"
+#
+# - name: Restart iptables
+#   service:
+#     name: ufw
+#     state: reloaded
+#   when: ansible_os_family == "Debian"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,5 +1,5 @@
 ---
 
-- include: openvpn.yml
+- import_tasks: openvpn.yml
   when: openvpn_enabled
   tags: [openvpn]

--- a/tasks/openvpn.yml
+++ b/tasks/openvpn.yml
@@ -20,5 +20,7 @@
 
 - include: setup-bridge.yml
 
+- include: firewall.yml
+
 - name: Ensure OpenVPN is started
   service: name={{openvpn_service}} state=started enabled=yes

--- a/tasks/openvpn.yml
+++ b/tasks/openvpn.yml
@@ -10,17 +10,17 @@
       - "Common-default.yml"
       paths: vars
 
-- include: install.deb.yml
+- import_tasks: install.deb.yml
   when: ansible_os_family == 'Debian'
 
-- include: install.yum.yml
+- import_tasks: install.yum.yml
   when: ansible_os_family == 'RedHat'
 
-- include: configure.yml
+- import_tasks: configure.yml
 
-- include: setup-bridge.yml
+- import_tasks: setup-bridge.yml
 
-- include: firewall.yml
+- import_tasks: firewall.yml
 
 - name: Ensure OpenVPN is started
   service: name={{openvpn_service}} state=started enabled=yes

--- a/templates/server.conf.j2
+++ b/templates/server.conf.j2
@@ -168,3 +168,7 @@ script-security 3 execve
 {% if crl_pem_file.stat.exists %}
 crl-verify {{openvpn_keydir}}/crl.pem
 {% endif %}
+
+{% for dns in openvpn_dns %}
+push "dhcp-option DNS {{ dns }}"
+{% endfor %}


### PR DESCRIPTION
According to this commit https://github.com/ansible/ansible/pull/25399, starting with Ansible 2.4 using include to include tasks will be deprecated. Instead, import_tasks should be used. Note that this backwards incompatible.