### PR TITLE
 Replace include with import_tasks to avoid ansible deprecation warnings

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -63,6 +63,19 @@
   notify: openvpn pack clients
   register: openvpn_clients_changed
 
+- name: Create system user
+  user:
+    name: "{{ openvpn_user }}"
+    shell: /usr/bin/nologin
+    system: 'yes'
+    state: present
+
+- name: Create system group
+  group:
+    name: "{{ openvpn_group }}"
+    system: 'yes'
+    state: present
+
 - name: Setup PAM
   template: src=openvpn.pam.j2 dest=/etc/pam.d/openvpn
   when: openvpn_use_pam

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -43,7 +43,7 @@
   args: { removes: "{{ openvpn_keydir }}/{{item}}.crt" }
   with_items: "{{ openvpn_clients_revoke }}"
 
-- include: read-client-files.yml
+- import_tasks: read-client-files.yml
   when: openvpn_unified_client_profiles
 
 - name: Create client configuration directory if requested

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,5 +1,5 @@
 ---
 
-- include: openvpn.yml
+- import_tasks: openvpn.yml
   when: openvpn_enabled
   tags: [openvpn]

--- a/tasks/openvpn.yml
+++ b/tasks/openvpn.yml
@@ -10,15 +10,15 @@
       - "Common-default.yml"
       paths: vars
 
-- include: install.deb.yml
+- import_tasks: install.deb.yml
   when: ansible_os_family == 'Debian'
 
-- include: install.yum.yml
+- import_tasks: install.yum.yml
   when: ansible_os_family == 'RedHat'
 
-- include: configure.yml
+- import_tasks: configure.yml
 
-- include: setup-bridge.yml
+- import_tasks: setup-bridge.yml
 
 - name: Ensure OpenVPN is started
   service: name={{openvpn_service}} state=started enabled=yes


### PR DESCRIPTION
According to this commit ansible/ansible#25399, starting with Ansible 2.4 using include to include tasks will be deprecated. Instead, import_tasks should be used. Note that this backwards incompatible.