### PR TITLE
Set this content only if openvpn_tls_auth : True

### DIFF
--- a/tasks/read-client-files.yml
+++ b/tasks/read-client-files.yml
@@ -32,4 +32,8 @@
     openvpn_ca_file_contents: "{{ openvpn_read_ca_file_results.stdout }}"
     openvpn_client_cert_output: "{{ openvpn_read_client_cert_files_results.results }}"
     openvpn_client_keys_output: "{{ openvpn_read_client_key_files_results.results }}"
+
+- name: Set tls auth file contents as fact.
+  set_fact:
     openvpn_tls_auth_file_contents: "{{ openvpn_read_tlsauth_file_results['content'] | b64decode | default('') }}"
+  when: openvpn_tls_auth 


### PR DESCRIPTION
If not it will throw an exception.

TASK [stouts.openvpn : Set client cert and CA info as fact.] **************************************************************************************
fatal: [XXX]: FAILED! => {"failed": true, "msg": "the field 'args' has an invalid value, which appears to include a variable that is undefined. The error was: 'dict object' has no attribute 'content'\n\nThe error appears to have been in 'XXX/roles/stouts.openvpn/tasks/read-client-files.yml': line 30, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n- name: Set client cert and CA info as fact.\n  ^ here\n"}