### PR TITLE
modified to use gpg keyserver instead of the https url

### DIFF
--- a/tasks/install.deb.yml
+++ b/tasks/install.deb.yml
@@ -3,7 +3,7 @@
 - name: Add OpenVPN repo GPG key
   apt_key:
     id: E158C569
-    url: https://swupdate.openvpn.net/repos/repo-public.gpg
+    keyserver: keyserver.ubuntu.com
   when: openvpn_use_external_repo
 
 - name: Add OpenVPN repo sources


### PR DESCRIPTION
`
    googlecompute: TASK [Stouts.openvpn : Add OpenVPN repo GPG key] **********
    googlecompute: fatal: [default]: FAILED! => {"changed": false, "failed": true, "msg": "Failed to download key at https://swupdate.openvpn.net/repos/repo-public.gpg: HTTP Error 403: Forbidden"}`