### PR TITLE
Fix indent of example

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,12 +120,11 @@ Example:
   - Stouts.openvpn
 
   vars:
-  openvpn_use_pam: yes
-  openvpn_clients: [myvpn]
-  openvpn_use_pam_users:
-  - { name: user1, password: password1 }
-  - { name: user2, password: password2 }
-
+    openvpn_use_pam: yes
+    openvpn_clients: [myvpn]
+    openvpn_use_pam_users:
+    - { name: user1, password: password1 }
+    - { name: user2, password: password2 }
 ```
 
 Install and copy client's configuration from `/etc/openvpn/keys/myvpn.tar.gz` file.


### PR DESCRIPTION
Some variables for openvpn should be defined under `vars`.