### PR TITLE
Add router capabilities to the OS

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ openvpn_use_system_easyrsa: false                   # Install EasyRSA from syste
 openvpn_host: "{{inventory_hostname}}"              # The server address
 openvpn_port: 1194
 openvpn_proto: udp
-openvpn_dev: tun
+openvpn_dev: tun                                    # The device type - Will trigger ip_forward/iptables setup
 openvpn_server: 10.8.0.0 255.255.255.0
 openvpn_max_clients: 100
 openvpn_log: /var/log/openvpn.log                   # Log's directory

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -15,6 +15,7 @@ openvpn_port: 1194
 openvpn_proto: udp
 openvpn_dev: tun
 openvpn_server: 10.8.0.0 255.255.255.0              # Set empty for skip
+openvpn_server_iptables: 10.8.0.0/24                # Used on server up
 openvpn_bridge: {}
 openvpn_max_clients: 100
 openvpn_log: /var/log/openvpn.log                   # Log's directory

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -87,6 +87,20 @@
   template: src=server.conf.j2 dest={{openvpn_etcdir}}/server.conf
   notify: [openvpn restart]
 
+- name: Setup server.up.sh script
+  template: src=server.up.sh.j2 dest={{openvpn_etcdir}}/server.up.sh mode=0755
+  notify: [openvpn restart]
+  when: "'tun' in openvpn_dev"
+
+- name: Load ip_tables module
+  command: "modprobe ip_tables"
+  notify: [openvpn restart]
+  when: "'tun' in openvpn_dev"
+
+- name: Add ip_tables to /etc/modules
+  lineinfile: path=/etc/modules line="ip_tables"
+  when: "'tun' in openvpn_dev"
+
 - name: Ensure openvpn key dir has the right permission
   file: path={{openvpn_keydir}} state=directory mode=0700 owner={{openvpn_user}}
 

--- a/templates/server.conf.j2
+++ b/templates/server.conf.j2
@@ -128,6 +128,11 @@ verb {{openvpn_verb}}
 # The maximum number of concurrently connected clients we want to allow.
 max-clients {{openvpn_max_clients}}
 
+{% if openvpn_dev.startswith('tun') %}
+# Server up - Script that runs on server initialization
+up /etc/openvpn/server.up.sh
+{% endif %}
+
 # It's a good idea to reduce the OpenVPN daemon's privileges after
 # initialization.
 #

--- a/templates/server.up.sh.j2
+++ b/templates/server.up.sh.j2
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+#
+# This script will be run by OpenVPN on startup via the 'up' configuration
+# directive in /etc/openvpn/server.conf.
+#
+
+# Turn on IP forwarding
+/sbin/sysctl -w net.ipv4.ip_forward=1
+
+# Setup iptables forwarding
+iptables -A FORWARD -i tun+ -j ACCEPT
+iptables -A FORWARD -i tun+ -o eth0 -m state --state RELATED,ESTABLISHED -j ACCEPT
+iptables -A FORWARD -i eth0 -o tun+ -m state --state RELATED,ESTABLISHED -j ACCEPT
+iptables -t nat -A POSTROUTING -s {{ openvpn_server_iptables }} -o eth0 -j MASQUERADE
+


### PR DESCRIPTION
With this change if the openvpn_dev is set to tun Ansible will setup a `server.up.sh` script that will automatically configure the server as a Linux router (ip_forward + iptables rules) on the service startup.