### PR TITLE
Provide limited support for v6

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ openvpn_port: 1194
 openvpn_proto: udp
 openvpn_dev: tun
 openvpn_server: 10.8.0.0 255.255.255.0
+# Should be a network address with CIDR, example:
+# openvpn_server_v6: fc00:0:abc:def::/64
 openvpn_max_clients: 100
 openvpn_log: /var/log/openvpn.log                   # Log's directory
 openvpn_keepalive: "10 120"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -15,6 +15,8 @@ openvpn_port: 1194
 openvpn_proto: udp
 openvpn_dev: tun
 openvpn_server: 10.8.0.0 255.255.255.0              # Set empty for skip
+# Should be a network address with CIDR, example:
+# openvpn_server_v6: fc00:0:abc:def::/64
 openvpn_bridge: {}
 openvpn_max_clients: 100
 openvpn_log: /var/log/openvpn.log                   # Log's directory

--- a/templates/server.conf.j2
+++ b/templates/server.conf.j2
@@ -61,13 +61,15 @@ client-config-dir {{ openvpn_client_config_dir }}
 topology {{ openvpn_topology }}
 {% endif %}
 
-{% if openvpn_server and not openvpn_bridge %}
+{% if ( openvpn_server or openvpn_server_v6 ) and not openvpn_bridge %}
 # Configure server mode and supply a VPN subnet for OpenVPN to draw client
 # addresses from. The server will take 10.8.0.1 for itself, the rest will be
 # made available to clients. Each client will be able to reach the server on
 # 10.8.0.1. Comment this line out if you are ethernet bridging. See the man
 # page for more info.
-server {{ openvpn_server }}
+{% if openvpn_server %}server {{ openvpn_server }}{% endif %}
+
+{% if openvpn_server_v6 %}server-ipv6 {{ openvpn_server_v6 }}{% endif %}
 {% endif %}
 {% if openvpn_bridge %}
 # Configure server mode for ethernet bridging.


### PR DESCRIPTION
Technically this option could have been provided under the `openvpn_server_options` variable as-is seemed to make more sense to match the ipv4 server option though.

I noticed there was another PR to add push route support, i'm doing that currently under the `openserver_server_options` list :) 