### PR TITLE
Don't attempt to read openvpn_tls_auth_file_contents if skipped

### DIFF
--- a/tasks/read-client-files.yml
+++ b/tasks/read-client-files.yml
@@ -32,7 +32,8 @@
     openvpn_ca_file_contents: "{{ openvpn_read_ca_file_results.stdout }}"
     openvpn_client_cert_output: "{{ openvpn_read_client_cert_files_results.results }}"
     openvpn_client_keys_output: "{{ openvpn_read_client_key_files_results.results }}"
+
 - name: Set tls info as fact.
   set_fact:
     openvpn_tls_auth_file_contents: "{{ openvpn_read_tlsauth_file_results['content'] | b64decode | default('') }}"
-    when: openvpn_tls_auth
+  when: openvpn_tls_auth

--- a/tasks/read-client-files.yml
+++ b/tasks/read-client-files.yml
@@ -32,4 +32,7 @@
     openvpn_ca_file_contents: "{{ openvpn_read_ca_file_results.stdout }}"
     openvpn_client_cert_output: "{{ openvpn_read_client_cert_files_results.results }}"
     openvpn_client_keys_output: "{{ openvpn_read_client_key_files_results.results }}"
+- name: Set tls info as fact.
+  set_fact:
     openvpn_tls_auth_file_contents: "{{ openvpn_read_tlsauth_file_results['content'] | b64decode | default('') }}"
+    when: openvpn_tls_auth


### PR DESCRIPTION
Tested by running locally.

Attempting to read `openvpn_read_tlsauth_file_results` when the creating task was skipped results in an error. This fixes that. 