### PR TITLE
Fix: Systemd service for Ubuntu Xenial(16.04)

### DIFF
--- a/vars/Ubuntu.xenial.yml
+++ b/vars/Ubuntu.xenial.yml
@@ -2,4 +2,4 @@
 openvpn_use_pam_plugin_distribution: /usr/lib/openvpn/openvpn-plugin-auth-pam.so
 openvpn_use_ldap_plugin_distribution: /usr/lib/openvpn/openvpn-auth-ldap.so
 
-openvpn_service: openvpn
+openvpn_service: openvpn@server


### PR DESCRIPTION
In my experience `openvpn@server` works instead of `openvpn`. I'm *not* using the upstream repo just in case that makes a difference.