### PR TITLE
add option to check certificates with pam also

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -78,6 +78,9 @@ openvpn_clients:
 # Revoke clients certificates
 openvpn_clients_revoke: []
 
+# Set to true to enable checking client certificates even with pam authentication (disabled for pan authentication by default by default)
+openvpn_client_cert_required: false
+
 # Use PAM authentication
 openvpn_use_pam: true
 openvpn_use_pam_users: []

--- a/templates/server.conf.j2
+++ b/templates/server.conf.j2
@@ -159,8 +159,11 @@ group nogroup
 client-to-client
 {% endif %}
 
-{% if openvpn_use_pam %}
+{% if openvpn_use_pam and not openvpn_client_cert_required %}
 client-cert-not-required
+{% endif %}
+
+{% if openvpn_use_pam %}
 plugin {{openvpn_use_pam_plugin|default(openvpn_use_pam_plugin_distribution)}} openvpn
 {% endif %}
 


### PR DESCRIPTION
By default client certificate checking is disabled when using pam authentication. This adds additional variable to make certificate checking an option even with pam.