### PR TITLE
Support for Ubuntu 18.04 #124

### DIFF
--- a/tasks/easy-rsa.yml
+++ b/tasks/easy-rsa.yml
@@ -24,20 +24,20 @@
 
 # TODO revisit this in relation to
 # https://github.com/Stouts/Stouts.openvpn/pull/107
-- name: Fix openssl.cnf path on Debian Stretch
+- name: Fix openssl.cnf path on Debian Stretch/Ubuntu Bionic
   file:
     src: "{{ openvpn_etcdir + '/easy-rsa/openssl-1.0.0.cnf' }}"
     dest: "{{ openvpn_etcdir + '/easy-rsa/openssl.cnf' }}"
     state: link
   when:
-    - ansible_distribution_release == 'stretch'
+    - ansible_distribution_release == 'stretch' or ansible_distribution_release == 'bionic'
     - not openvpn_use_system_easyrsa | bool
 
-- name: Fix openssl.cnf path on Debian Stretch with system easyrsa
+- name: Fix openssl.cnf path on Debian Stretch/Ubuntu Bionic with system easyrsa
   file:
     src: /usr/share/easy-rsa/openssl-1.0.0.cnf
     dest: /usr/share/easy-rsa/openssl.cnf
     state: link
   when:
-    - ansible_distribution_release == 'stretch'
+    - ansible_distribution_release == 'stretch' or ansible_distribution_release == 'bionic'
     - openvpn_use_system_easyrsa | bool

--- a/tasks/easy-rsa.yml
+++ b/tasks/easy-rsa.yml
@@ -30,7 +30,8 @@
     dest: "{{ openvpn_etcdir + '/easy-rsa/openssl.cnf' }}"
     state: link
   when:
-    - ansible_distribution_release == 'stretch' or ansible_distribution_release == 'bionic'
+    - ansible_distribution_release == 'stretch' or
+      ansible_distribution_release == 'bionic'
     - not openvpn_use_system_easyrsa | bool
 
 - name: Fix openssl.cnf path on Debian Stretch/Ubuntu Bionic with system easyrsa
@@ -39,5 +40,6 @@
     dest: /usr/share/easy-rsa/openssl.cnf
     state: link
   when:
-    - ansible_distribution_release == 'stretch' or ansible_distribution_release == 'bionic'
+    - ansible_distribution_release == 'stretch' or
+      ansible_distribution_release == 'bionic'
     - openvpn_use_system_easyrsa | bool


### PR DESCRIPTION
So, I've looked at this for a few months now and keep coming back to the very simple solution that has been previously applied by linking `/easy-rsa/openssl.cnf` to `/easy-rsa/openssl-1.0.0.cnf`.  You can see that this approach is taken for Debian Stretch as well.

I've tested this with `openvpn_use_system_easyrsa` set to `false` (the default).  I have not tested it with `openvpn_use_system_easyrsa` set to `true`.

