### PR TITLE
Fix to bug in handlers with ansible_lsb.codename

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -23,14 +23,14 @@
       command: /etc/init.d/iptables-persistent save
       when:
         - ansible_os_family == "Debian"
-        - ansible_lsb.codename == "trusty"
+        - ansible_distribution_release == "trusty"
       listen: openvpn save iptables
 
     - name: Save the rules (Ubuntu)
       command: netfilter-persistent save
       when:
         - ansible_os_family == "Debian"
-        - ansible_lsb.codename != "trusty"
+        - ansible_distribution_release != "trusty"
       listen: openvpn save iptables
 
 - name: Restart OpenVPN service


### PR DESCRIPTION
Hi, thanks for share. With **Ansible 2.8.4** on a **Debian Stretch** server, I get the following error when the handlers are going to run:
```
FAILED! => {"msg": "The conditional check 'ansible_lsb.codename == \"trusty\"' failed. 
The error was: error while evaluating conditional (ansible_lsb.codename == \"trusty\"): 
'dict object' has no attribute 'codename'
```
One fix for this problem is that what I propose in this PR: replace `ansible_lsb.codename` with `ansible_distribution_release`.