### PR TITLE
replace openvpn_client_config_dir with openvpn_ccd

### DIFF
--- a/templates/server.conf.j2
+++ b/templates/server.conf.j2
@@ -57,8 +57,8 @@ tls-server
 {% endif %}
 
 # Client configuration directory.
-{% if openvpn_client_config_dir is defined -%}
-client-config-dir {{ openvpn_client_config_dir }}
+{% if openvpn_ccd is defined -%}
+client-config-dir {{ openvpn_ccd }}
 {% endif %}
 
 # Which VPN topology to use? (net30, subnet, p2p)


### PR DESCRIPTION
openvpn_client_config_dir variable is used in this template but is not defined elsewhere.
openvpn_ccd is defined in default variables so use this one.