### PR TITLE
support scheme in LDAP server URL

### DIFF
--- a/templates/auth-ldap.conf.j2
+++ b/templates/auth-ldap.conf.j2
@@ -1,6 +1,7 @@
 <LDAP>
   # LDAP server URL
-  URL   ldap://{{ openvpn_ldap_server }}
+  URL   {% if openvpn_ldap_server | regex_search('(^\w+:\/\/.+$)') %}{{ openvpn_ldap_server }}{% else %}ldap://{{ openvpn_ldap_server }}{% endif %}
+  
 
   # Bind DN (If your LDAP server doesn't support anonymous binds)
   # e.g. cn=administrator,cn=users,dc=ctc,dc=local

--- a/templates/auth-ldap.conf.j2
+++ b/templates/auth-ldap.conf.j2
@@ -1,5 +1,9 @@
 <LDAP>
   # LDAP server URL
+  # possible values are:
+  #  - ldapserver.example.org
+  #  - ldap://ldapserver.example.org
+  #  - ldaps://ldapserver.example.org
   URL   {% if openvpn_ldap_server | regex_search('(^\w+:\/\/.+$)') %}{{ openvpn_ldap_server }}{% else %}ldap://{{ openvpn_ldap_server }}{% endif %}
   
 


### PR DESCRIPTION
makes openvpn_ldap_server variable more configurable.

if openvpn_ldap_server contains a full URI (with a scheme) it will be used as is.
otherwise, defaults to ldap://

if openvpn_ldap_server is undefined. the regex search will obviously fail.
since other variables of the template aren't checked. I don't do it for openvpn_ldap_server as well.

closes https://github.com/Stouts/Stouts.openvpn/issues/138