### PR TITLE
FIX correct path for ldap auth.so

### DIFF
--- a/vars/os/Ubuntu.bionic.yml
+++ b/vars/os/Ubuntu.bionic.yml
@@ -2,6 +2,6 @@
 
 openvpn_use_pam_plugin_distribution: /usr/lib/x86_64-linux-gnu/openvpn/plugins/openvpn-plugin-auth-pam.so
 
-openvpn_use_ldap_plugin_distribution: /usr/lib/x86_64-linux-gnu/openvpn/openvpn-auth-ldap.so
+openvpn_use_ldap_plugin_distribution: /usr/lib/openvpn/openvpn-auth-ldap.so 
 
 openvpn_service: openvpn


### PR DESCRIPTION
Didn't mean to change the ldap.so location when I previously updated the other path.