### PR TITLE
create the ovpn directory that does not exist

### DIFF
--- a/meta/.galaxy_install_info
+++ b/meta/.galaxy_install_info
@@ -1,0 +1,1 @@
+{install_date: 'Fri Jan 24 11:58:21 2020', version: ''}

--- a/tasks/authentication/tls.yml
+++ b/tasks/authentication/tls.yml
@@ -1,5 +1,10 @@
 ---
 
+- name: Create client configuration directory
+  file:
+    path: "{{ openvpn_etcdir }}/ovpns"
+    state: directory
+
 - name: Generate tls-auth key
   command:
     openvpn --genkey --secret "{{ openvpn_etcdir }}/ovpns/{{ openvpn_tls_key }}"


### PR DESCRIPTION
When using tls, ta.key is created first but the directory does not exist