### PR TITLE
Whitespace bug stopping keepliave statement from working

### DIFF
--- a/templates/server.conf.j2
+++ b/templates/server.conf.j2
@@ -104,7 +104,7 @@ ifconfig-pool-persist {{ openvpn_ifconfig_pool_persist }}
 # over the link so that each side knows when the other side has gone down. Ping
 # every 10 seconds, assume that remote peer is down if no ping received during
 # a 120 second time period.
-{%- if openvpn_keepalive != '' %}
+{% if openvpn_keepalive != '' %}
 keepalive {{ openvpn_keepalive }}
 {% endif %}
 


### PR DESCRIPTION
The `-` in the jinga2 block intro is causing the keepalive statement to be
appended to the previous line's comment, resulting in keepalive values
not being configured. Without this, you get

```
# a 120 second time period.keepalive 10 120
```

Instead of

```
# a 120 second time period.
keepalive 10 120
```
