### PR TITLE
Fix example playbook link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ The files can be found under the `meta/` folder.
 
 ## Example playbook
 
-See [molecule/default/playbook.yml](molecule/default/playbook.yml) for a working
+See [molecule/default/converge.yml](molecule/default/converge.yml) for a working
 example of how to use this role.
 
 


### PR DESCRIPTION
When I want to use this Role in Ansible by reading the README.md, I can't find the mentioned example file. Then I checked the commits, found it was renamed by this commit(https://github.com/Stouts/Stouts.openvpn/commit/26146756c671c6f5594907f0e86d16bf8e55f1c8). So create this PR to fix the link in the README.md