### PR TITLE
Use different Base DN for LDAP group search

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -174,8 +174,15 @@ openvpn_use_pam_users: []
 
 # LDAP authentication and configuration (optional)
 openvpn_use_ldap: false
+openvpn_ldap_server:  # ldapserver.example.org or ldap://ldapserver.example.org
 openvpn_ldap_tlsenable: 'false'
 openvpn_ldap_follow_referrals: 'false'
+openvpn_ldap_bind_dn:  # cn=administrator,cn=users,dc=ctc,dc=local
+openvpn_ldap_bind_password:
+openvpn_ldap_base_dn:  # dc=ctc,dc=local
+openvpn_ldap_search_filter: # sAMAccountName=%u
+openvpn_ldap_group_base_dn:  # ou=groups,dc=ctc,dc=local if empty fallback to openvpn_ldap_base_dn
+openvpn_ldap_group_search_filter:  # cn=OpenVPNUsers
 
 # Use simple authentication (default is disabled)
 openvpn_simple_auth: false

--- a/templates/authentication/auth-ldap.conf.j2
+++ b/templates/authentication/auth-ldap.conf.j2
@@ -45,10 +45,12 @@
   # e.g. "sAMAccountName=%u"
   SearchFilter  {{ openvpn_ldap_search_filter }}
   RequireGroup  true
+  {% if openvpn_ldap_group_search_filter %}
   <Group>
-    BaseDN    {{ openvpn_ldap_base_dn }}
+    BaseDN    {{ openvpn_ldap_group_base_dn | default(openvpn_ldap_base_dn) }}
     # e.g. "cn=OpenVPNUsers"
     SearchFilter  {{ openvpn_ldap_group_search_filter }}
     MemberAttribute Member
   </Group>
+  {% endif %}
 </Authorization>


### PR DESCRIPTION
This commit features a variable to allow using different base-dn for ldap groups.

Also added sample values for LDAP related variables in `default/main.yml`